### PR TITLE
Wrong conditional statement

### DIFF
--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -578,7 +578,7 @@ def create_version(args):
                     session, policy_id=policy_policy_id)
                 root_logger.info(
                     'Trying to create a new version of this policy...')
-                if policy_create_response.status_code == 200 or 201:
+                if policy_create_response.status_code == 200 or policy_create_response==201:
                     new_version = policy_create_response.json()['version']
                     policy_update_response = cloudlet_object.update_policy_version(
                         session, policy_policy_id, policy_details_json, new_version)


### PR DESCRIPTION
One of the status code check for response code was wrong. It was written as this:
```python
if policy_create_response.status_code == 200 or 210:
   # do stuff
```

This was causing an error. Even when the response code was a 500, the condition would match as "201" would always evaluate to true. I've corrected this statement with this code:

```python
if policy_create_response.status_code == 200 or policy_create_response==201:
   #do stuff
```